### PR TITLE
Add temporary workaround for High DPI

### DIFF
--- a/SDK10069/CompositionVisual/cs/compositionvisual/VisualProperties.cs
+++ b/SDK10069/CompositionVisual/cs/compositionvisual/VisualProperties.cs
@@ -272,6 +272,12 @@ namespace compositionvisual
 
             _root = _compositor.CreateContainerVisual();
 
+            #region temp dpi fix
+            //temporary: manually correct for DPI
+            float dpiScaleFactor = (float)Windows.Graphics.Display.DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+            _root.Scale = new Vector3(dpiScaleFactor, dpiScaleFactor, 1.0f);
+            #endregion
+
             _compositionTarget = _compositor.CreateTargetForCurrentView();
             _compositionTarget.Root = _root;
 


### PR DESCRIPTION
We will be adding platform support for High DPI in frameworkless composition apps in futures builds.  This temporarily corrects rendering for it in the BUILD2015 build.